### PR TITLE
Adding admin settings to toggle image and article downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ testing-roffline-sqlite.db
 testing-roffline-sqlite.db.db-journal
 esbuild-meta.json
 esbuild-stats.html
+node_modules

--- a/db/db-first-run.ts
+++ b/db/db-first-run.ts
@@ -16,6 +16,8 @@ const defaultAdminSettings = {
   updateAllDay: true,
   updateStartingHour: 1,
   updateEndingHour: 5, // eslint-disable-line @typescript-eslint/no-magic-numbers
+  downloadImages: true,
+  downloadArticles: true,
 }
 
 async function populateTablesOnFirstRun(): Promise<void> {

--- a/db/entities/AdminSettings.ts
+++ b/db/entities/AdminSettings.ts
@@ -11,6 +11,8 @@ type AdminSettings = {
   updateAllDay: boolean
   updateStartingHour: number
   updateEndingHour: number
+  downloadImages: boolean
+  downloadArticles: boolean
 }
 
 class AdminSettingsModel extends Model {}
@@ -67,6 +69,16 @@ const tableSchema = {
     defaultValue: 5, // eslint-disable-line @typescript-eslint/no-magic-numbers
     validate: { min: 0, max: 23 }, // eslint-disable-line @typescript-eslint/no-magic-numbers
   },
+  downloadImages: {
+    type: DataTypes.BOOLEAN,
+    allowNull: false,
+    defaultValue: true,
+  },
+  downloadArticles: {
+    type: DataTypes.BOOLEAN,
+    allowNull: false,
+    defaultValue: true,
+  },
 }
 
 const initAdminSettingsModel = (sequelize: Sequelize): Promise<AdminSettingsModel> => {
@@ -81,7 +93,7 @@ const initAdminSettingsModel = (sequelize: Sequelize): Promise<AdminSettingsMode
       },
     },
   })
-  return AdminSettingsModel.sync()
+  return AdminSettingsModel.sync({ alter: true })
 }
 
 export { initAdminSettingsModel, AdminSettingsModel, AdminSettings }

--- a/downloads/media/download-media-decider.ts
+++ b/downloads/media/download-media-decider.ts
@@ -38,7 +38,9 @@ function downloadIndividualPostMedia({ post, adminSettings, postMediaFolder }: M
   }
 
   if (isImagePost(post)) {
-    return downloadImage(post, adminSettings, postMediaFolder)
+    return adminSettings.downloadImages
+    ? downloadImage(post, adminSettings, postMediaFolder)
+    : skipDownload('Image downloads disabled', post)
   }
 
   if (isVideoPost(post)) {
@@ -48,7 +50,9 @@ function downloadIndividualPostMedia({ post, adminSettings, postMediaFolder }: M
   }
 
   if (isArticleToSaveAsPdf(post)) {
-    return savePageAsPdf(post, postMediaFolder)
+    return adminSettings.downloadArticles
+    ? savePageAsPdf(post, postMediaFolder)
+      : skipDownload('Article downloads disabled', post)
   }
 
   if (isTextPostWithNoUrlInPost(post)) {

--- a/frontend/js/admin/admin-db-viewer-page/admin-db-viewer-page-types.d.ts
+++ b/frontend/js/admin/admin-db-viewer-page/admin-db-viewer-page-types.d.ts
@@ -13,6 +13,8 @@ type AdminSettings = {
   updateAllDay: boolean
   updateStartingHour: number
   updateEndingHour: number
+  downloadImages: boolean
+  downloadArticles: boolean
 }
 
 type SubredditsMasterListRow = {

--- a/frontend/js/admin/admin-db-viewer-page/table-columns.ts
+++ b/frontend/js/admin/admin-db-viewer-page/table-columns.ts
@@ -173,6 +173,18 @@ const tablesColumns = {
       formatFn: sqliteBoolToString,
     },
     {
+      label: 'downloadImages',
+      field: 'downloadImages',
+      type: 'boolean',
+      formatFn: sqliteBoolToString,
+    },
+    {
+      label: 'downloadArticles',
+      field: 'downloadArticles',
+      type: 'boolean',
+      formatFn: sqliteBoolToString,
+    },
+    {
       label: 'videoDownloadMaxFileSize',
       field: 'videoDownloadMaxFileSize',
     },

--- a/frontend/js/admin/admin-frontend-global-types.ts
+++ b/frontend/js/admin/admin-frontend-global-types.ts
@@ -8,6 +8,8 @@ type AdminSettingsForFrontend = {
   updateAllDay: boolean
   updateStartingHour: number
   updateEndingHour: number
+  downloadImages: boolean
+  downloadArticles: boolean
 }
 
 type AdminSettingsPageWindowWithProps = {

--- a/server/routes/api-router-schema.ts
+++ b/server/routes/api-router-schema.ts
@@ -98,6 +98,8 @@ const updateAdminSettingsSchema = {
           'updateAllDay',
           'updateStartingHour',
           'updateEndingHour',
+          'downloadImages',
+          'downloadArticles',
         ],
       },
       settingValue: { type: ['boolean', 'number', 'string'] },

--- a/server/views/admin/admin-settings-page.njk
+++ b/server/views/admin/admin-settings-page.njk
@@ -23,7 +23,28 @@
               Enable Downloading Of Comments
             </label>
           </p>
-
+          <p>
+            <label for="enable-article-downloads" class="checkbox-label">
+              <input
+                id="enable-article-downloads"
+                name="checkbox"
+                type="checkbox"
+                v-model="downloadArticles"
+              />
+              Enable Downloading Of Articles (PDF)
+            </label>
+          </p>
+          <p>
+            <label for="enable-image-downloads" class="checkbox-label">
+              <input
+                id="enable-image-downloads"
+                name="checkbox"
+                type="checkbox"
+                v-model="downloadImages"
+              />
+              Enable Downloading Of Images
+            </label>
+          </p>
           <p>
             <label for="enable-video-downloads" class="checkbox-label">
               <input

--- a/tests/e2e/empty-db/admin-settings-page.test.ts
+++ b/tests/e2e/empty-db/admin-settings-page.test.ts
@@ -75,6 +75,8 @@ test.describe('Admin Settings Page', () => {
         'updateAllDay',
         'updateStartingHour',
         'updateEndingHour',
+        'downloadImages',
+        'downloadArticles',
       ])
 
       expect(typeof settingValue).to.be.oneOf(['boolean', 'number', 'string'])

--- a/tests/test-utils.ts
+++ b/tests/test-utils.ts
@@ -166,7 +166,7 @@ const removeAllSubreddits = async (): Promise<void> => {
 
 const resetAdminSettingsBackToDefault = async (): Promise<void> => {
   await DB.run(
-    `UPDATE admin_settings SET downloadComments = true, numberFeedsOrPostsDownloadsAtOnce = 4, numberMediaDownloadsAtOnce = 2, downloadVideos = false, videoDownloadMaxFileSize = '300', videoDownloadResolution = '480p', updateAllDay = true, updateStartingHour = 1, updateEndingHour = 5;`
+    `UPDATE admin_settings SET downloadComments = true, numberFeedsOrPostsDownloadsAtOnce = 4, numberMediaDownloadsAtOnce = 2, downloadVideos = false, downloadImages = true, downloadArticles = true, videoDownloadMaxFileSize = '300', videoDownloadResolution = '480p', updateAllDay = true, updateStartingHour = 1, updateEndingHour = 5;`
   )
 }
 


### PR DESCRIPTION
I made these changes for myself, so only proceed with this PR if you are interested.

This change allows users to not download images or PDFs of articles if they choose.

---

This change adds two new boolean settings to the admin settings page:
* Enable Downloading Of Articles (PDF)
* Enable Downloading Of Images

Both default to true, so there should be no change from your current code if the user doesn't change these settings.
I added `{ alter: true }` to your `return AdminSettingsModel.sync()` so these changes should be backwards compatible as well.

I tested against an existing installation and it added the 2 new columns to the existing database.
